### PR TITLE
fix invalid function error

### DIFF
--- a/WorldMap/SvgToBezier.m
+++ b/WorldMap/SvgToBezier.m
@@ -172,7 +172,7 @@ unichar const invalidCommand		= '*';
 				return nil;
 			}
 			// Maintain scale.
-			pathScale = (abs(value) > pathScale) ? abs(value) : pathScale;
+			pathScale = (fabsf(value) > pathScale) ? fabsf(value) : pathScale;
 			[token addValue:value];
 		}
 		


### PR DESCRIPTION
Change `abs` function to `fabsf` because the argument and return value are
floats, and `fabsf` does that. This change fix the error.
It's small, but at least someone else would be ready to go without errors.